### PR TITLE
Add 'required: false' to products and productstlyes

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,4 @@
 class Product < ApplicationRecord
   has_many :product_styles
-  belongs_to :attachment
+  belongs_to :attachment, required: false
 end

--- a/app/models/product_styles.rb
+++ b/app/models/product_styles.rb
@@ -1,6 +1,6 @@
 class ProductStyles < ApplicationRecord
   belongs_to :product
   belongs_to :style
-  belongs_to :attachment
+  belongs_to :attachment, required: false
   has_many :attachments
 end


### PR DESCRIPTION
This ended up being simpler than expected. 

Rails 5 belongs to association automates to true `belongs_to foo, required: true`

Rails 4 and under was set to false. I just had to set false and it was fixed.

closes #12 